### PR TITLE
fix typing_extensions for versions < 3.8

### DIFF
--- a/.github/pr-labeler.yml
+++ b/.github/pr-labeler.yml
@@ -1,4 +1,4 @@
-feature: ['feature/*', 'feat/*'],
+feature: ['feature/*', 'feat/*']
 bug: ['fix/*', 'bugfix/*']
 maintenance: ['maintenance/*', 'cleanup/*']
 dependencies: ['dependencies/*', 'deps/*']

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 collectionish>=0.3.0
 torch
+typing_extensions; python_version < '3.8'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.0
+current_version = 0.1.1
 
 [bumpversion:file:setup.py]
 search = version='{current_version}'

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/leaprovenzano/keyedtensor',
-    version='0.1.0',
+    version='0.1.1',
     zip_safe=False,
 )

--- a/src/keyedtensor/__init__.py
+++ b/src/keyedtensor/__init__.py
@@ -4,6 +4,6 @@
 
 __author__ = """Lea Provenzano"""
 __email__ = 'leaprovenzano@gmail.com'
-__version__ = '0.1.0'
+__version__ = '0.1.1'
 
 from ._keyedtensor import KeyedTensor

--- a/src/keyedtensor/_keyedtensor.py
+++ b/src/keyedtensor/_keyedtensor.py
@@ -1,5 +1,11 @@
-from typing_extensions import Literal
+import sys
 from typing import List, Union, Optional
+
+if sys.version_info < (3, 8):
+    from typing_extensions import Literal
+else:
+    from typing import Literal
+
 import numpy as np
 
 import torch


### PR DESCRIPTION
We should only install typing_extensions if < 3.8. typing extensions was missing in previous release.